### PR TITLE
Wireframe 1 for mobilstørrelse landsskapsmodus

### DIFF
--- a/Source Code/index.html
+++ b/Source Code/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Enkel Prototype</title>
+    <link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+    <div class="screen"></div>
+</body>
+</html>

--- a/Source Code/style.css
+++ b/Source Code/style.css
@@ -1,0 +1,13 @@
+html, body {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+}
+
+.screen {
+    width: 568px;
+    height: 320px;
+    border: 2px solid black;
+    margin-top: 50px;
+}


### PR DESCRIPTION
Dette er den helt grunnleggende koden som oppretter en synlig wireframe for prototype 1 av nettsiden. Dette er for å vise at alle elementene skal kunne passe inn i rektangelet i midten av skjermen, og dermed kunne skaleres opp basert på vindusstørrelsen. I utgangspunktet kan vi implementere alt vi skal via denne koden, og bare plassere alle elementene vi skal ha med inne i rektangelet som har klassenavn "screen". 

Størrelsen av rektangelet er basert på landsskapsmoduset til iPhone SE, den minste vanlige smartphone skjermen på markedet. Når vi har designet alle elementene i Figma i sprint 1, så kan vi bygge på denne koden for å implementere designvalgene, og bruke responsivt design til å skalere elementene og gå fra vertikal modus på mobil til landsskapsmodus og videre til pc skjerm.